### PR TITLE
pull rebase: Add --delete-branch option

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1492,6 +1492,10 @@ class RebaseCmd (PullUtil):
 			action='store_true', default=False,
 			help="uses git stash save --all when stashing local "
 			"changes")
+		parser.add_argument('-D', '--delete-branch',
+			action='store_true', default=False,
+			help="removes the PR branch, like the Delete "
+			"Branch button (TM)")
 
 	@classmethod
 	def run(cls, parser, args):
@@ -1757,6 +1761,11 @@ class RebaseCmd (PullUtil):
 					base_ref, base_url)
 			git_push(base_url, 'HEAD:' + base_ref,
 					force=args.force_push)
+			if args.delete_branch:
+				infof('Removing pull request branch {} in {}',
+						head_ref, head_url)
+				git_push(head_url, ':' + head_ref,
+						force=args.force_push)
 			return git('rev-parse HEAD')
 		finally:
 			if not cls.in_conflict and not cls.in_pause:

--- a/man.rst
+++ b/man.rst
@@ -363,6 +363,11 @@ COMMANDS
       cleaned in addition to the untracked files, which completely removes the
       possibility of conflicts when checking out the pull request to reabase.
 
+    \-D, --delete-branch
+      Delete the pull request branch if the rebase was successful. This is
+      similar to press the "Delete Branch" Button (TM) in the web interface
+      after merging.
+
     Actions:
 
     \--continue


### PR DESCRIPTION
This would delete the branch after rebasing:

```
git hub pull rebase --delete
```

It saves from having to do it manually or via `git push <fork> :<branch>`.