### PR TITLE
setup: Ask the user for another note if the current is taken

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -649,9 +649,10 @@ class SetupCmd (object):
 
 	@classmethod
 	def run(cls, parser, args):
+		is_global = ('--system' in args.opts or
+				'--global' in args.opts)
 		try:
-			if '--system' not in args.opts and \
-					'--global' not in args.opts:
+			if not is_global:
 				git('rev-parse --git-dir')
 		except GitError as error:
 			errf(error.output)
@@ -679,7 +680,7 @@ class SetupCmd (object):
 		req.set_basic_auth(username, password)
 
 		note = 'git-hub'
-		if config.forkrepo:
+		if not is_global and config.forkrepo:
 			proj = config.forkrepo.split('/', 1)[1]
 			note += ' (%s)' % proj
 

--- a/git-hub
+++ b/git-hub
@@ -684,17 +684,29 @@ class SetupCmd (object):
 			proj = config.forkrepo.split('/', 1)[1]
 			note += ' (%s)' % proj
 
-		infof("Looking for GitHub authorization tokens...")
-		auths = dict([(a['note'], a)
+		while True:
+			infof("Looking for GitHub authorization token...")
+			auths = dict([(a['note'], a)
 				for a in req.get('/authorizations')])
-		if note in auths:
-			auth = auths[note]
-			infof("Reusing existing token '{}' (id: {})", note,
-					auth['id'])
-		else:
-			infof("Creating auth token '{}'", note)
-			auth = req.post('/authorizations', note=note,
-					scopes=['user', 'repo'])
+
+			if note not in auths:
+				break
+
+			errf("The OAuth token with name '{}' already exists.",
+				note)
+			infof("If you want to create a new one, enter a "
+				"name for it. Otherwise you can go to "
+				"https://github.com/settings/tokens to "
+				"regenerate or delete the token '{}'", note)
+			note = raw_input("Enter a new token name (an empty "
+				"name cancels the setup): ")
+
+			if not note:
+				sys.exit(0)
+
+		infof("Creating auth token '{}'", note)
+		auth = req.post('/authorizations', note=note,
+				scopes=['user', 'repo'])
 
 		set_config = lambda k, v: git_config(k, value=v, opts=args.opts)
 


### PR DESCRIPTION
The GitHub API changed and it doesn't return access tokens anymore. To avoid the whole trouble now the note is generated using a timestamp as fingerprint, so an unique auth will be create for each `setup` call.

This solution might end up creating dozens of different auth tokens, which might be a security hazard. Another proposed solution is to just fail if a token exists and ask the user if they want to replace the current token, or if they want to choose a different *note* (name) for the token (thus creating a new token, but with the user's knowledge and authorization). Maybe even specifying an command-line option to use a custom note could be a good idea.