### PR TITLE
setup: Feeding EOF to the prompted inputs causes a crash

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -115,6 +115,13 @@ class InterruptException (Exception):
 	def __init__(self, msg):
 		super(InterruptException, self).__init__(msg)
 
+# Wrapper for raw_input to treat EOF as an empty input
+def user_input(*args, **kwargs):
+	try:
+		return raw_input(*args, **kwargs)
+	except EOFError:
+		sys.stdout.write('\n')
+		return ''
 
 # Ask the user a question
 #
@@ -153,7 +160,7 @@ def ask(question, default=None, options=["yes", "no"]):
 	while True:
 		# question in yellow
 		sys.stderr.write('\033[33m' + question + '\033[0m')
-		choice = raw_input().lower().strip()
+		choice = user_input().lower().strip()
 		if default is not None and choice == '':
 			return default
 		elif choice in valid_answers:
@@ -665,12 +672,16 @@ class SetupCmd (object):
 			die("Can't perform an interactive setup outside a tty")
 		if username is None:
 			username = config.username or getpass.getuser()
-			reply = raw_input('GitHub username [%s]: ' % username)
+			reply = user_input('GitHub username [%s]: ' % username)
 			if reply:
 				username = reply
 		if password is None:
-			password = getpass.getpass(
-				'GitHub password (will not be stored): ')
+			try:
+				password = getpass.getpass('GitHub '
+					'password (will not be stored): ')
+			except EOFError:
+				sys.stdout.write('\n')
+				password = ''
 		if '@' in username:
 			infof("E-mail used to authenticate, trying to "
 					"retrieve the GitHub username...")
@@ -698,7 +709,7 @@ class SetupCmd (object):
 				"name for it. Otherwise you can go to "
 				"https://github.com/settings/tokens to "
 				"regenerate or delete the token '{}'", note)
-			note = raw_input("Enter a new token name (an empty "
+			note = user_input("Enter a new token name (an empty "
 				"name cancels the setup): ")
 
 			if not note:


### PR DESCRIPTION
```
$ git hub setup
GitHub username [stefan-brus-sociomantic]:       
GitHub password (will not be stored): Traceback (most recent call last):
  File "/usr/bin/git-hub", line 1973, in <module>
    main()
  File "/usr/bin/git-hub", line 1967, in main
    args.run(parser, args)
  File "/usr/bin/git-hub", line 672, in run
    'GitHub password (will not be stored): ')
  File "/usr/lib/python2.7/getpass.py", line 71, in unix_getpass
    passwd = _raw_input(prompt, stream, input=input)
  File "/usr/lib/python2.7/getpass.py", line 135, in _raw_input
    raise EOFError
EOFError
```

In this example I pressed enter at the username prompt, then CTRL+D at the password prompt. It is possible to reproduce this by pressing CTRL+D at either prompt.