### PR TITLE
non-ASCII comments cause UnicodeEncodeError

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -972,7 +972,7 @@ class IssueUtil (object):
 
 	@classmethod
 	def print_comment(cls, comment):
-		body = comment['body'].decode('UTF8')
+		body = comment['body']
 		infof(u'[{id}] {}{} ({user[login]})', body[:60],
 				u'…' if len(body) > 60 else u'',
 				u' ' * (len(str(comment['id'])) + 3),


### PR DESCRIPTION
When you add a comment that contains non-ASCII characters, you get the following exception:
```
Traceback (most recent call last):
  File "/usr/bin/git-hub", line 2003, in <module>
    main()
  File "/usr/bin/git-hub", line 1997, in main
    args.run(parser, args)
  File "/usr/bin/git-hub", line 614, in check_config_and_run
    cmd.run(parser, args)
  File "/usr/bin/git-hub", line 1164, in run
    cls.clean_and_post_comment(args.issue, body)
  File "/usr/bin/git-hub", line 974, in clean_and_post_comment
    cls.print_comment(comment)
  File "/usr/bin/git-hub", line 945, in print_comment
    body = comment['body'].decode('UTF8')
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u263a' in position 14: ordinal not in range(128)
```