### PR TITLE
Verbose cloning causes UnicodeDecodeError in debugf().

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -453,7 +453,7 @@ class RequestManager:
 			debugf("Request: {} {}\n{}", method, url, body)
 			res = self.auth_urlopen(url, method, body)
 			data = res.read()
-			debugf("Response:\n{}", data)
+			debugf("Response:\n{}", data.decode('UTF8'))
 			if data:
 				data = json.loads(data)
 				if isinstance(data, list):


### PR DESCRIPTION
```
$ git hub -v clone sociomantic/git-hub
...
https://api.github.com/user/repos?page=3
Content-length: 0
Content-type: application/json
Authorization: <hidden>
Accept: application/vnd.github.v3+json
None
Traceback (most recent call last):
  File "/usr/bin/git-hub", line 2017, in <module>
    main()
  File "/usr/bin/git-hub", line 2011, in main
    args.run(parser, args)
  File "/usr/bin/git-hub", line 615, in check_config_and_run
    cmd.run(parser, args)
  File "/usr/bin/git-hub", line 769, in run
    '{}/{}'.format(owner, proj))
  File "/usr/bin/git-hub", line 813, in set_not_own_repo_params
    for repo in req.get('/user/repos'):
  File "/usr/bin/git-hub", line 479, in <lambda>
    self.json_req(url, method, *args, **kwargs)
  File "/usr/bin/git-hub", line 457, in json_req
    debugf("Response:\n{}", data)
  File "/usr/bin/git-hub", line 74, in debugf
    localeprintf(sys.stdout, fmt, *args, **kwargs)
  File "/usr/bin/git-hub", line 65, in localeprintf
    msg = fmt.decode(encoding, 'replace').format(*args, **kwargs) + '\n'
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 124672: ordinal not in range(128)
```